### PR TITLE
Fixed demo and docs link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ Vue.use(VAnimateCss);
 
 ```
 
-Demo and Docs [here](https://jofftiquez.github.io/v-animate-css/).
+Demo and Docs [here](https://ossphilippines.github.io/v-animate-css/). 
 
 Made with :heart: by Jofferson Ramirez Tiquez


### PR DESCRIPTION
It seems this repo previously has changed organization, that's why demo and docs link doesn't work anymore. This small fix updates readme with correct link.